### PR TITLE
update TcT's solver configuration IDs

### DIFF
--- a/Y2020_info.php
+++ b/Y2020_info.php
@@ -304,9 +304,11 @@ $competition = [
 				'type' => 'complexity',
 //				'jobid' => 41221,
 				'parts' => [
+                                        "TcT" => 360388,
 				],
 				'certified' => [
 					'parts' => [
+                                                "TcT" => 360387,
 					],
 				],
 			],
@@ -315,9 +317,11 @@ $competition = [
 				'type' => 'complexity',
 //				'jobid' => 41222,
 				'parts' => [
+                                        "TcT" => 360385,
 				],
 				'certified' => [
 					'parts' => [
+                                                "TcT" => 360391,
 					],
 				],
 			],
@@ -326,9 +330,11 @@ $competition = [
 				'type' => 'complexity',
 //				'jobid' =>  41223,
 				'parts' => [
+                                        "TcT" => 360390,
 				],
 				'certified' => [
 					'parts' => [
+                                                "TcT" => 360389,
 					],
 				],
 			],
@@ -337,9 +343,11 @@ $competition = [
 				'type' => 'complexity',
 //				'jobid' =>  41224,
 				'parts' => [
+                                        "TcT" => 360386,
 				],
 				'certified' => [
 					'parts' => [
+                                                "TcT" => 360384,
 					],
 				],
 			],


### PR DESCRIPTION
After switching to BenchExec which solves the "backtrace" errors (https://github.com/StarExec/StarExec/issues/258) and adapting TcT's output to the new postprocessor  (https://github.com/jwaldmann/ceta-postproc/issues/23), it seems that everything works as expected.