### PR TITLE
matchbox for certified SRS categories

### DIFF
--- a/Y2023/info.php
+++ b/Y2023/info.php
@@ -51,7 +51,7 @@ $categories = [
 					'TTT2' => 552235,
 					'AProVE' => 748138,
 					'NaTT' => 552278,
-//					'matchbox' => 671248,
+					'matchbox' => 748828,
 				],
 			],
 		],
@@ -91,6 +91,7 @@ $categories = [
 				'participants' => [
 					'TTT2' => 552235,
 					'AProVE' => 748138,
+					'matchbox' => 748828,
 				],
 			],
 		],


### PR DESCRIPTION
Hi Akihisa, if you can allow this, here is matchbox for certified SRS categories. I expect these UNSUPPORTED (by CeTA) errors, and I have no resources to repair them now:

* (both standard and relative) output is "YES" (only, without certificate, because printing the certificate runs into time-out)
* (relative) `parse error on <trs> at [split, ...`, see  https://lists.rwth-aachen.de/hyperkitty/list/termtools@lists.rwth-aachen.de/thread/ZT7GQJV5FBUSITSUQGC662KNNJOGKKVZ/