### PR TITLE
replace incorrect MuVal configuration

### DIFF
--- a/Y2024/info.php
+++ b/Y2024/info.php
@@ -278,7 +278,7 @@ $categories = [
 				//				'iRankFinder' => null,
 				'LoAT' => 747594,
 				'KoAT' => 748986, // We disabled control-flow refinement by iRankFinder in this category.
-				'MuVal' => 789730,
+				'MuVal' => 789717,
 			],
 			'certified' => [
 				'id' => null,


### PR DESCRIPTION
Replace the incorrectly registered configuration for the C Integer category of MuVal in the Integer Transition Systems category with the correct one.